### PR TITLE
fix: Resolve TypeError in CI and address deprecation warning

### DIFF
--- a/reasoningbank/core/bank.py
+++ b/reasoningbank/core/bank.py
@@ -7,7 +7,7 @@ from ..utils.config import load_config
 from ..memory.chroma import ChromaMemoryBackend
 from ..memory.json import JSONMemoryBackend
 from sentence_transformers import SentenceTransformer
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms import FakeListLLM
 
 # Placeholder for a generic Embedding Model interface.
 # The user would provide a model with an `embed_documents` method.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-chromadb
+chromadb==0.4.15
 sentence-transformers
 langchain
 numpy
 scikit-learn
 PyYAML
 langchain-community
+posthog==3.0.0


### PR DESCRIPTION
- Pins `chromadb` to `0.4.15` and `posthog` to `3.0.0` in `requirements.txt` to resolve a `TypeError` caused by an incompatibility with Python 3.8.
- Updates the import for `FakeListLLM` to use `langchain_community` to address a `LangChainDeprecationWarning`.