### PR TITLE
fix(deps): add langchain_classic to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 PyYAML
 langchain-community
 posthog==3.0.0
+langchain_classic


### PR DESCRIPTION
The CI build was failing with a ModuleNotFoundError because the langchain_classic package was not listed in the dependencies. This change adds the missing package to requirements.txt to ensure it is installed during the CI process.