### PR TITLE
Fix Failing Build by Removing langchain_classic from Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scikit-learn
 PyYAML
 langchain-community
 posthog==3.0.0
-langchain_classic


### PR DESCRIPTION
The build was failing because 'langchain_classic' was listed in 'requirements.txt', but it is not a distributable package on PyPI. This change removes the erroneous dependency, allowing the build to succeed. The necessary 'langchain_classic' modules are included in the main 'langchain' package.