### PR TITLE
🧹 chore: remove unused posthog dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ numpy
 scikit-learn
 PyYAML
 langchain-community
-posthog==3.0.0


### PR DESCRIPTION
This PR removes the unused `posthog` dependency from the `requirements.txt` file.

🎯 **What:** Removed `posthog==3.0.0` from `requirements.txt`.
💡 **Why:** The dependency is not used anywhere in the codebase. Removing it improves maintainability by reducing the number of external dependencies and potential security vulnerabilities.
✅ **Verification:** Grepped the codebase for "posthog" and confirmed it's only present in the requirements file before removal and absent after. Ran the test suite; although tests failed due to environment issues, no new regressions related to this change were observed.
✨ **Result:** A cleaner dependency list for the project.

---
*PR created automatically by Jules for task [5449771101183219768](https://jules.google.com/task/5449771101183219768) started by @thakshak*